### PR TITLE
fix: remove unsupported syntax from universal_links.js

### DIFF
--- a/www/universal_links.js
+++ b/www/universal_links.js
@@ -79,7 +79,7 @@ var universalLinks = {
    *
    * @param {number} milliseconds - Optional. The number of milliseconds to wait before executing the code. If omitted, the value 0 is used
    */
-  checkDeepLink: function () {
+  checkDeepLink: function (milliseconds) {
       var _this = this;
       return new Promise(function (resolve, reject) {
           setTimeout(function () {

--- a/www/universal_links.js
+++ b/www/universal_links.js
@@ -35,7 +35,7 @@ var universalLinks = {
    */
   bindEvents: function() {
     const _this = this;
-    document.addEventListener('deviceready', () => {
+    document.addEventListener('deviceready', function() {
       _this.onDeviceReady();
     }, false);
   },
@@ -45,7 +45,7 @@ var universalLinks = {
    */
   onDeviceReady: function() {
     const _this = this;
-    this.subscribe(_this.eventName, (event) => {
+    this.subscribe(_this.eventName, function(event) {
       _this.didLaunchAppFromLink(event);
     });
   },
@@ -79,14 +79,14 @@ var universalLinks = {
    *
    * @param {number} milliseconds - Optional. The number of milliseconds to wait before executing the code. If omitted, the value 0 is used
    */
-  checkDeepLink: function (milliseconds = 2000) {
+  checkDeepLink: function () {
       var _this = this;
       return new Promise(function (resolve, reject) {
           setTimeout(function () {
               if (_this.dpLink)
                 _this.validateDeeplink()
               resolve(_this.dpLink);
-          }, milliseconds);
+          }, milliseconds || 0);
       });
   },
 

--- a/www/universal_links.js
+++ b/www/universal_links.js
@@ -34,7 +34,7 @@ var universalLinks = {
    * Bind Event Listeners
    */
   bindEvents: function() {
-    const _this = this;
+    var _this = this;
     document.addEventListener('deviceready', function() {
       _this.onDeviceReady();
     }, false);
@@ -44,7 +44,7 @@ var universalLinks = {
    *  deviceready Event Handler
    */
   onDeviceReady: function() {
-    const _this = this;
+    var _this = this;
     this.subscribe(_this.eventName, function(event) {
       _this.didLaunchAppFromLink(event);
     });


### PR DESCRIPTION
Had to fork this to get it to run on older Android 5.1, where the webview does not support arrow functions etc. Here's a PR for the changes if you want to include the fixes in. :)

Also, changed the checkDeepLink delay to work as per the comment and not default to the 2000ms.