### PR TITLE
Fix Cordova 9 support

### DIFF
--- a/hooks/lib/ios/xcodePreferences.js
+++ b/hooks/lib/ios/xcodePreferences.js
@@ -147,7 +147,7 @@ function loadProjectFile() {
           projectFile = platform_ios.parseProjectFile(iosPlatformPath());
       } catch (e) {
           // Then cordova 7.0
-          var project_files = context.requireCordovaModule('glob').sync(path.join(iosPlatformPath(), '*.xcodeproj', 'project.pbxproj'));
+          var project_files = require('glob').sync(path.join(iosPlatformPath(), '*.xcodeproj', 'project.pbxproj'));
           
           if (project_files.length === 0) {
               throw new Error('does not appear to be an xcode project (no xcode project file)');
@@ -155,13 +155,13 @@ function loadProjectFile() {
           
           var pbxPath = project_files[0];
           
-          var xcodeproj = context.requireCordovaModule('xcode').project(pbxPath);
+          var xcodeproj = require('xcode').project(pbxPath);
           xcodeproj.parseSync();
           
           projectFile = {
               'xcode': xcodeproj,
               write: function () {
-                  var fs = context.requireCordovaModule('fs');
+                  var fs = require('fs');
                   
               var frameworks_file = path.join(iosPlatformPath(), 'frameworks.json');
               var frameworks = {};
@@ -172,7 +172,7 @@ function loadProjectFile() {
               fs.writeFileSync(pbxPath, xcodeproj.writeSync());
                   if (Object.keys(frameworks).length === 0){
                       // If there is no framework references remain in the project, just remove this file
-                      context.requireCordovaModule('shelljs').rm('-rf', frameworks_file);
+                      require('shelljs').rm('-rf', frameworks_file);
                       return;
                   }
                   fs.writeFileSync(frameworks_file, JSON.stringify(this.frameworks, null, 4));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-deeplinks",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
   "cordova": {
     "id": "cordova-plugin-deeplinks",


### PR DESCRIPTION
Replace `context.requireCordovaModule` with normal `require` where needed.