### PR TITLE
Support cordova-cli 9.0.0 - requireCordovaModule deprecation 

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,11 +30,15 @@
     "cordova-android": ">=4"
   },
   "dependencies": {
+    "cordova-lib": "^9.0.1",
+    "glob": "^7.1.4",
     "mkpath": ">=1.0.0",
-    "xml2js": ">=0.4",
-    "rimraf": ">=2.4",
     "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
+    "plist": ">=1.2.0",
+    "rimraf": ">=2.4",
+    "shelljs": "^0.8.3",
+    "xcode": "^2.0.0",
+    "xml2js": ">=0.4"
   },
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",


### PR DESCRIPTION
The use of context.requireCordovaModule for non-cordova dependencies has been removed, and suggests you now add the dependency to the plugins package.json and require'd normally.

edit xcodePreferences.js

add to node modules at package.json 