### PR TITLE
Do not crash when app is opened via custom uri

### DIFF
--- a/hooks/lib/configXmlParser.js
+++ b/hooks/lib/configXmlParser.js
@@ -51,7 +51,7 @@ function readPreferences(cordovaContext) {
 // region Private API
 
 function getTeamIdPreference(xmlPreferences) {
-  if (xmlPreferences.hasOwnProperty('ios-team-id')) {
+  if (Object.prototype.hasOwnProperty.call(xmlPreferences, 'ios-team-id')) {
     return xmlPreferences['ios-team-id'][0]['$']['value'];
   }
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xml2js": ">=0.4",
     "rimraf": ">=2.4",
     "node-version-compare": ">=1.0.1",
-    "plist": ">=1.2.0"
+    "plist": ">=1.2.0, <4.0.0"
   },
   "author": "Nikolay Demyankov for Nordnet Bank AB",
   "license": "MIT",

--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -206,10 +206,15 @@ public class UniversalLinksPlugin extends CordovaPlugin {
      */
     private ULHost findHostByUrl(Uri url) {
         ULHost host = null;
-        final String launchHost = url.getHost().toLowerCase();
+        final String launchHost = url.getHost();
+        if (launchHost == null)
+            // e.g. custom URIs like com.example.app:/oauthlogin
+            return null;
+        final String launchHostLc = launchHost.toLowerCase();
         for (ULHost supportedHost : supportedHosts) {
-            if (supportedHost.getName().equals(launchHost) ||
-                    supportedHost.getName().startsWith("*.") && launchHost.endsWith(supportedHost.getName().substring(1))) {
+            final String name = supportedHost.getName();
+            if (name.equals(launchHostLc) ||
+                    name.startsWith("*.") && launchHostLc.endsWith(name.substring(1))) {
                 host = supportedHost;
                 break;
             }


### PR DESCRIPTION
The intent handler is also triggered for custom URIs like
com.example.app:/oauthlogin; In this case getHost() returns null and
the plugin crashes.

I think thats a pretty uncontroversial change, just fix a potential null dereference error.