### PR TITLE
Bugfix for Android platform, InAppBrowser incompatible issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.3.2 (2018-04-23)
+
+**Bug fixes:**
+
+- fixed issue about the android-web-hook path 
+
 ## 2.3.1 (2018-03-05)
 
 **Bug fixes:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 2.3.1 (2018-03-05)
+
+**Bug fixes:**
+
+- Improved the default Regular Exp to extract the activation code 
+
 ## 2.3.0 (2018-02-26)
 
 **Docs:**

--- a/README.md
+++ b/README.md
@@ -46,16 +46,10 @@ It is important not only to redirect users to your app from the web, but also pr
 - [Additional documentation links](#additional-documentation-links)
 
 ### Installation
-This requires cordova 5.0+ (current stable 1.2.1)
+Install via repo url directly (version 2.3.1)
 
 ```sh
-cordova plugin add cordova-universal-links-plugin
-```
-
-It is also possible to install via repo url directly (**unstable**)
-
-```sh
-cordova plugin add https://github.com/nordnet/cordova-universal-links-plugin.git
+cordova plugin add https://github.com/foneclay/cordova-universal-links-plugin.git#2.3.1
 ```
 
 ### Migrating from previous versions
@@ -351,7 +345,10 @@ universalLinks.subscribe(null, function (eventData) {
   "params": {
     "foo": "bar"
   },
-  "hash": "cordova-news"
+  "hash": "cordova-news",
+  "regex": /\b[\w-]+$/gm, // default value
+  "value": [], // It returns the value extracted from the deeplink object using the regex parameter
+  "match": false // "false" is default. It returns true if the magic-link match the specific domain
 }
 ```
 
@@ -489,46 +486,20 @@ Now, let's say, you want your app to handle all links from `myhost.com`, but you
 2. Add handling for default UL event in the `www/js/index.js`:
 
   ```js
-  var app = {
-    // Application Constructor
-    initialize: function() {
-      this.bindEvents();
-    },
+      universalLinks.initialize({host: 'https://my-domain.com/', eventName: 'event', regex: '/^.+token=/'}); // change the default values to match a specific host and an event name specified into the config.xml
 
-    // Bind Event Listeners
-    bindEvents: function() {
-      document.addEventListener('deviceready', this.onDeviceReady, false);
-    },
+      universalLinks.checkDeepLink(3000) // wait 3000 ms before to make sure that a deeplink exists or not
+        .then(dpLink => {
+          ...
+        })
 
-    // deviceready Event Handler
-    onDeviceReady: function() {
-      console.log('Handle deviceready event if you need');
-      universalLinks.subscribe('openNewsListPage', app.onNewsListPageRequested);
-      universalLinks.subscribe('openNewsDetailedPage', app.onNewsDetailedPageRequested);
-      universalLinks.subscribe('launchedAppFromLink', app.onApplicationDidLaunchFromLink);
-    },
+  // NOTE: if it exists, the deeplink variable is also accessible using "universalLinks.dpLink"
 
-    // openNewsListPage Event Handler
-    onNewsListPageRequested: function(eventData) {
-      console.log('Showing to user list of awesome news');
+  /** Use the following HELPER attributes to check if the deeplink matches the host specified above and retrieve a specific value using the regex parameter  */
 
-      // do some work to show list of news
-    },
+  universalLinks.dpLink.match // true or false
 
-    // openNewsDetailedPage Event Handler
-    onNewsDetailedPageRequested: function(eventData) {
-      console.log('Showing to user details page for some news');
-
-      // do some work to show detailed page
-    },
-
-    // launchedAppFromLink Event Handler
-    onApplicationDidLaunchFromLink: function(eventData) {
-      console.log('Did launch app from the link: ' + eventData.url);
-    }
-  };
-
-  app.initialize();
+  universalLinks.dpLink.value // ["123456"] --> get the token from the initial magic-link (e.g: 'https://my-domain.com/webapp/invitation?token="123456"')
   ```
 
 That's it! Now, by default for `myhost.com` links `onApplicationDidLaunchFromLink` method will be called, but for `news` section - `onNewsListPageRequested` and `onNewsDetailedPageRequested`.

--- a/hooks/lib/android/webSiteHook.js
+++ b/hooks/lib/android/webSiteHook.js
@@ -12,7 +12,7 @@ var path = require('path');
 var mkpath = require('mkpath');
 var ConfigXmlHelper = require('../configXmlHelper.js');
 var WEB_HOOK_FILE_PATH = path.join('ul_web_hooks', 'android', 'android_web_hook.html');
-var WEB_HOOK_TPL_FILE_PATH = path.join('plugins', 'cordova-universal-links-plugin', 'ul_web_hooks', 'android_web_hook_tpl.html');
+var WEB_HOOK_TPL_FILE_PATH = path.join('plugins', 'cordova-deeplink', 'ul_web_hooks', 'android_web_hook_tpl.html');
 var LINK_PLACEHOLDER = '[__LINKS__]';
 var LINK_TEMPLATE = '<link rel="alternate" href="android-app://<package_name>/<scheme>/<host><path>" />';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-deeplink",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
   "cordova": {
     "id": "cordova-deeplink",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-deeplink",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Cordova plugin to add in your application support for Universal Links (iOS 9) and Deep Links (Android). Basically, open application through the link in the browser.",
   "cordova": {
     "id": "cordova-deeplink",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<plugin id="cordova-deeplink" version="2.3.0" xmlns="http://apache.org/cordova/ns/plugins/1.0">
+<plugin id="cordova-deeplink" version="2.3.1" xmlns="http://apache.org/cordova/ns/plugins/1.0">
 
   <name>Cordova Deeplink</name>
   <description>

--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -182,7 +182,7 @@ public class UniversalLinksPlugin extends CordovaPlugin {
 
         // if app was not launched by the url - ignore
         if (!Intent.ACTION_VIEW.equals(action) || launchUri == null) {
-            Log.d("app was not launched by the url: ", action);
+            Log.d("UniversalLinks", "App was not launched by the url: " + action);
             return;
         }
 
@@ -196,6 +196,12 @@ public class UniversalLinksPlugin extends CordovaPlugin {
         // store message and try to consume it
         storedMessage = new JSMessage(host, launchUri);
         tryToConsumeEvent();
+        /*
+         * inAppBrowser breaks the intent load feature, just remove the data in Intent to avoid duplicated call deeplink features,
+         * this case is only happend with no SPA application,
+         * once user goBack to the index page from deeplink, it will trigger again deeplink logic. to fix this bug, only clear the data.
+         * */
+        intent.setData(null);
     }
 
     /**

--- a/www/universal_links.js
+++ b/www/universal_links.js
@@ -17,7 +17,7 @@ var universalLinks = {
   dpLink: null,
   host: '',
   eventName: null,
-  regex: /\b[\w-]+$/gm, // /^.+token=/,
+  regex: /\b[\d-]+$/gm, // /^.+token=/,
 
   /**
    * Initialize the deeplink


### PR DESCRIPTION
Bug appears in no SPA application, once the app installed with inAppBrowser Plugin.
Duplicated Deeplink logic will be triggered once the user navigates back from deeplink route to the root page.