### PR TITLE
fix deeplink plugin no compatible issue with inAppBrowser plugin for Android platform

### DIFF
--- a/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
+++ b/src/android/com/nordnetab/cordova/ul/UniversalLinksPlugin.java
@@ -196,6 +196,12 @@ public class UniversalLinksPlugin extends CordovaPlugin {
         // store message and try to consume it
         storedMessage = new JSMessage(host, launchUri);
         tryToConsumeEvent();
+        /*
+         * inAppBrowser breaks the intent load feature, just remove the data in Intent to avoid duplicated call deeplink features,
+         * this case is only happend with no SPA application,
+         * once user goBack to the index page from deeplink, it will trigger again deeplink logic. to fix this bug, only clear the data.
+         * */
+        intent.setData(null);
     }
 
     /**


### PR DESCRIPTION
fix one bug for inAppBrowser compatibility issue once the app is not built based on SPA, Once the app navigates back to the root page from deeplink, will trigger deeplink logic again.
Only fixed for Android platform.